### PR TITLE
fix:  header not full width on big screens

### DIFF
--- a/jportal/src/components/Header.jsx
+++ b/jportal/src/components/Header.jsx
@@ -14,7 +14,7 @@ const Header = ({ setIsAuthenticated }) => {
 
   return (
     <header className="bg-[#191c20] mx-auto px-3 pt-4 pb-2">
-      <div className="container flex justify-between items-center">
+      <div className="container-fluid flex justify-between items-center">
         <h1 className="text-white text-2xl font-bold lg:text-3xl font-sans">
           JPortal
         </h1>


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/03ae6181-5695-4be6-bda4-7e5a25dc6ff5)

After:
![image](https://github.com/user-attachments/assets/7b54e18f-e2f9-4261-b807-7c47bb9d660e)
