### PR TITLE
feat: Add password visibility toggle to login form

### DIFF
--- a/jportal/jsconfig.app.json
+++ b/jportal/jsconfig.app.json
@@ -1,10 +1,33 @@
 {
   "compilerOptions": {
-    // ...
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
-    }
-    // ...
-  }
+    },
+    "target": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": [
+    "src/**/*",
+    "*.js",
+    "*.jsx",
+    "vite.config.js"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "build"
+  ]
 }

--- a/jportal/src/components/Login.jsx
+++ b/jportal/src/components/Login.jsx
@@ -3,6 +3,7 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
 import * as z from "zod"
 import { Button } from "@/components/ui/button"
+import {Eye, EyeOff} from "lucide-react"
 import {
   Form,
   FormControl,
@@ -30,15 +31,22 @@ export default function Login({ onLoginSuccess, w }) {
     error: null,
     credentials: null
   });
+const [showPassword, setShowPassword] = useState(false);
 
-  // Initialize form
-  const form = useForm({
-    resolver: zodResolver(formSchema),
-    defaultValues: {
-      enrollmentNumber: "",
-      password: "",
-    },
-  })
+// Initialize form
+const form = useForm({
+  resolver: zodResolver(formSchema),
+  defaultValues: {
+    enrollmentNumber: "",
+    password: "",
+  },
+})
+
+
+// Toggle password visibility
+const togglePasswordVisibility = () => {
+  setShowPassword(!showPassword);
+};
 
   // Handle side effects in useEffect
   useEffect(() => {
@@ -136,7 +144,24 @@ export default function Login({ onLoginSuccess, w }) {
                 <FormItem>
                   <FormLabel className="text-white">Password</FormLabel>
                   <FormControl>
-                    <Input type="password" {...field} />
+                    <div className="relative">
+                      <Input 
+                        type={showPassword ? "text" : "password"} 
+                        {...field} 
+                        className="pr-10"
+                      />
+                      <button
+                        type="button"
+                        onClick={togglePasswordVisibility}
+                        className="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 hover:text-gray-600"
+                      >
+                        {showPassword ? (
+                          <EyeOff className="h-4 w-4" />
+                        ) : (
+                          <Eye className="h-4 w-4" />
+                        )}
+                      </button>
+                    </div>
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/jportal/vite.config.js
+++ b/jportal/vite.config.js
@@ -69,12 +69,16 @@ export default defineConfig({
   ],
   server: (() => {
     if (process.env.NODE_ENV === "development") {
+      const httpsConfig = fs.existsSync("./certs/localhost-key.pem") && fs.existsSync("./certs/localhost.pem") 
+        ? {
+            key: fs.readFileSync("./certs/localhost-key.pem"),
+            cert: fs.readFileSync("./certs/localhost.pem"),
+          }
+        : false;
+
       return {
         host: true,
-        https: {
-          key: fs.readFileSync("./certs/localhost-key.pem"),
-          cert: fs.readFileSync("./certs/localhost.pem"),
-        },
+        https: httpsConfig,
       };
     }
     return { host: true };


### PR DESCRIPTION
- Added eye/eye-off icons using lucide-react for password toggle
- Implemented showPassword state and toggle functionality
- Updated password input to conditionally show/hide password
- Fixed vite.config.js to handle missing SSL certificates gracefully
- Updated jsconfig.app.json paths to match Vite project structure