### PR TITLE
adding attendance color codded progress

### DIFF
--- a/jportal/src/components/AttendanceCard.jsx
+++ b/jportal/src/components/AttendanceCard.jsx
@@ -16,6 +16,17 @@ const AttendanceCard = ({
   const attendancePercentage = attendance.total > 0 ? combined.toFixed(0) : "100";
   const displayName = name.replace(/\s*\([^)]*\)\s*$/, "");
 
+  // Determine the color variant based on attendance status
+  const getProgressVariant = () => {
+    if (classesNeeded > 2) {
+      return "danger"; // Need more than 2 classes - red/danger
+    } else if (classesNeeded > 0) {
+      return "warning"; // Need 1-2 classes - yellow/warning
+    } else {
+      return "primary"; // Can miss classes or on target - primary color
+    }
+  };
+
   const [isLoading, setIsLoading] = useState(false);
   const [selectedDate, setSelectedDate] = useState(null);
 
@@ -118,7 +129,7 @@ const AttendanceCard = ({
             <div className="text-sm">{attendance.total}</div>
           </div>
           <div className="flex flex-col items-center">
-            <CircleProgress key={Date.now()} percentage={attendancePercentage} />
+            <CircleProgress key={Date.now()} percentage={attendancePercentage} variant={getProgressVariant()} />
             {classesNeeded > 0 ? (
               <div className="text-xs mt-1 text-muted-foreground">Attend {classesNeeded}</div>
             ) : (

--- a/jportal/src/components/CircleProgress.jsx
+++ b/jportal/src/components/CircleProgress.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 
-function CircleProgress({ percentage, label, className = "" }) {
+function CircleProgress({ percentage, label, className = "", variant = "primary" }) {
   const strokeWidth = 3;
   const defaultRadius = 15;
   const radius = defaultRadius;
@@ -20,6 +20,19 @@ function CircleProgress({ percentage, label, className = "" }) {
     return () => clearTimeout(timer);
   }, [percentage, circumference]);
 
+  // Map variant to CSS variable
+  const getStrokeColor = () => {
+    switch (variant) {
+      case "danger":
+        return "var(--destructive)";
+      case "warning":
+        return "var(--chart-4)";
+      case "primary":
+      default:
+        return "var(--primary)";
+    }
+  };
+
   return (
     <svg className={`w-[80px] h-[80px] ${className}`} viewBox="0 0 50 50" preserveAspectRatio="xMidYMid meet">
       <g transform="rotate(-90 25 25)">
@@ -28,7 +41,7 @@ function CircleProgress({ percentage, label, className = "" }) {
           cy="25"
           r={radius}
           fill="transparent"
-          stroke="var(--primary)"
+          stroke={getStrokeColor()}
           strokeWidth={strokeWidth}
           strokeDasharray={circumference}
           strokeDashoffset={offset}


### PR DESCRIPTION
This pull request introduces a color-coded progress indicator to the attendance card, making it easier to visually assess attendance status. The main changes implement a `variant` prop for the `CircleProgress` component, allowing the progress circle's color to reflect whether a student is on track, at risk, or in danger of falling behind.

**Attendance status visualization improvements:**

* Added a `getProgressVariant` function in `AttendanceCard.jsx` to determine the color variant ("danger", "warning", "primary") based on how many more classes need to be attended.
* Passed the computed `variant` prop from `AttendanceCard.jsx` to the `CircleProgress` component, enabling dynamic color changes.

**CircleProgress component enhancements:**

* Updated `CircleProgress.jsx` to accept a `variant` prop and map it to the appropriate CSS variable for stroke color, supporting "danger", "warning", and "primary" states. [[1]](diffhunk://#diff-d4d82acf0bb6f1ed3205d964370ac738201f21f760d8e57f0c26145183550077L3-R3) [[2]](diffhunk://#diff-d4d82acf0bb6f1ed3205d964370ac738201f21f760d8e57f0c26145183550077R23-R35)
* Changed the progress circle's stroke color to use the new `getStrokeColor` logic, replacing the previous static color.