### PR TITLE
Addition of MOOC and ADD/DROP Status Pages

### DIFF
--- a/jportal/src/App.jsx
+++ b/jportal/src/App.jsx
@@ -47,6 +47,9 @@ function AuthenticatedApp({ w, setIsAuthenticated, setIsDemoMode }) {
   const [subjectChoicesLoading, setSubjectChoicesLoading] = useState(false);
   const [moocStatusData, setMoocStatusData] = useState({});
   const [moocStatusLoading, setMoocStatusLoading] = useState(false);
+  const [addDropStatusData, setAddDropStatusData] = useState({});
+  const [addDropStatusLoading, setAddDropStatusLoading] = useState(false);
+  const [addDropStatusError, setAddDropStatusError] = useState(null);
 
   const [gradesData, setGradesData] = useState({});
   const [gradesSemesterData, setGradesSemesterData] = useState(null);
@@ -252,6 +255,12 @@ function AuthenticatedApp({ w, setIsAuthenticated, setIsDemoMode }) {
               setMoocStatusData={setMoocStatusData}
               moocStatusLoading={moocStatusLoading}
               setMoocStatusLoading={setMoocStatusLoading}
+              addDropStatusData={addDropStatusData}
+              setAddDropStatusData={setAddDropStatusData}
+              addDropStatusLoading={addDropStatusLoading}
+              setAddDropStatusLoading={setAddDropStatusLoading}
+              addDropStatusError={addDropStatusError}
+              setAddDropStatusError={setAddDropStatusError}
             />
           }
         />

--- a/jportal/src/App.jsx
+++ b/jportal/src/App.jsx
@@ -15,7 +15,7 @@ import { DynamicFontLoader } from "./components/DynamicFontLoader";
 import { Toaster } from "./components/ui/sonner";
 import "./App.css";
 
-import { WebPortal, LoginError } from "https://cdn.jsdelivr.net/npm/jsjiit@0.0.27/dist/jsjiit.esm.js";
+import { WebPortal, LoginError } from "https://cdn.jsdelivr.net/npm/jsjiit@0.0.28/dist/jsjiit.esm.js";
 
 import MockWebPortal from "./components/MockWebPortal";
 import { TriangleAlert } from "lucide-react";
@@ -45,6 +45,8 @@ function AuthenticatedApp({ w, setIsAuthenticated, setIsDemoMode }) {
   const [subjectsLoading, setSubjectsLoading] = useState(true);
   const [subjectsDataLoading, setSubjectsDataLoading] = useState(true);
   const [subjectChoicesLoading, setSubjectChoicesLoading] = useState(false);
+  const [moocStatusData, setMoocStatusData] = useState({});
+  const [moocStatusLoading, setMoocStatusLoading] = useState(false);
 
   const [gradesData, setGradesData] = useState({});
   const [gradesSemesterData, setGradesSemesterData] = useState(null);
@@ -246,6 +248,10 @@ function AuthenticatedApp({ w, setIsAuthenticated, setIsDemoMode }) {
               setSubjectsLoading={setSubjectsDataLoading}
               choicesLoading={subjectChoicesLoading}
               setChoicesLoading={setSubjectChoicesLoading}
+              moocStatusData={moocStatusData}
+              setMoocStatusData={setMoocStatusData}
+              moocStatusLoading={moocStatusLoading}
+              setMoocStatusLoading={setMoocStatusLoading}
             />
           }
         />

--- a/jportal/src/components/AddDropStatus.jsx
+++ b/jportal/src/components/AddDropStatus.jsx
@@ -1,0 +1,69 @@
+import { CalendarDays, UserRound } from "lucide-react";
+import { Card } from "@/components/ui/card";
+
+const datePattern = /\d{1,2}-[A-Za-z]{3}-\d{4}\s+\d{1,2}:\d{2}\s+[AP]M/;
+
+function parseStage(raw, index) {
+  const [text, status = ""] = raw.split("@");
+  const date = text.match(datePattern)?.[0] || null;
+  const coordinator = text.match(/\bby\s+(.+?)(?:\s*\(|$)/i)?.[1]?.trim() || null;
+  const title = text.replace(datePattern, "").replace(/\bby\s+.+?(?:\s*\([^)]*\))?$/i, "").replace(/(?:Date:-|Submitted on)\s*$/i, "").replace(/^\d+\.\s*/, "").trim();
+  return { index, status, date, coordinator, title: title || text.trim() };
+}
+
+export default function AddDropStatus({ addDropStatus }) {
+  const requests = addDropStatus?.totalsubjectDetailList || [];
+  const rejectedSubjects = addDropStatus?.subjectListrejected || [];
+
+  if (requests.length === 0 && rejectedSubjects.length === 0) {
+    return <div className="flex items-center justify-center py-12 text-muted-foreground">No add/drop requests found for this semester</div>;
+  }
+
+  return (
+    <div className="mt-4 space-y-4 pb-4">
+      {requests.map((request, requestIndex) => {
+        const stages = (request.totalStages || []).filter(Boolean).map(parseStage);
+        const title = request.subjectdesc || request.subjectname || request.choicetype || "Add/Drop request";
+        const code = request.subjectcode || request.subjectid;
+        return (
+          <Card key={request.subjectid || `${title}-${requestIndex}`} className="overflow-hidden shadow-lg">
+            <div className="border-b border-border bg-muted/40 px-4 py-3">
+              <h3 className="text-sm font-semibold leading-tight text-card-foreground">{title}</h3>
+              {code && <p className="mt-1 font-mono text-xs text-muted-foreground">{code}</p>}
+              {request.choicetype && request.choicetype !== title && <p className="mt-3 text-xs leading-relaxed text-muted-foreground">{request.choicetype}</p>}
+            </div>
+            <div className="space-y-4 p-4">
+              {stages.map((stage, index) => (
+                <div key={`${requestIndex}-${stage.index}`} className="relative flex gap-3">
+                  {index < stages.length - 1 && <div className="absolute left-3 top-7 h-[calc(100%-0.25rem)] w-px bg-border" />}
+                  <div className={`relative z-10 flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-bold ${stage.status === "D" ? "bg-primary text-primary-foreground" : "bg-muted text-muted-foreground"}`}>{index + 1}</div>
+                  <div className="min-w-0 flex-1 pb-1">
+                    <p className="text-sm font-medium text-card-foreground">{stage.title}</p>
+                    <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1.5 text-xs text-muted-foreground">
+                      {stage.date && <span className="inline-flex items-center gap-1.5"><CalendarDays className="h-3.5 w-3.5" />{stage.date}</span>}
+                      {stage.coordinator && <span className="inline-flex items-center gap-1.5"><UserRound className="h-3.5 w-3.5" />{stage.coordinator}</span>}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </Card>
+        );
+      })}
+      {rejectedSubjects.length > 0 && (
+        <Card className="shadow-lg">
+          <div className="border-b border-border bg-muted/40 px-4 py-3"><h3 className="text-sm font-semibold text-card-foreground">Previous Rejected Subjects</h3></div>
+          <div className="divide-y divide-border">
+            {rejectedSubjects.map((subject, index) => (
+              <div key={`${subject.subjectcode}-${index}`} className="space-y-1 px-4 py-3 text-sm">
+                <p className="font-medium text-card-foreground">{subject.subjectdesc || subject.subjectcode}</p>
+                <p className="font-mono text-xs text-muted-foreground">{subject.subjectcode}</p>
+                {subject.referencesubjname && <p className="text-xs text-muted-foreground">Reference: {subject.referencesubjname} {subject.referencesubjcode && `(${subject.referencesubjcode})`}</p>}
+              </div>
+            ))}
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/jportal/src/components/MockWebPortal.js
+++ b/jportal/src/components/MockWebPortal.js
@@ -164,4 +164,22 @@ export default class MockWebPortal {
     };
   }
 
+  async get_add_drop_status_semesters() {
+    return [{ registrationid: "JIRUM26040000001", registrationcode: "2026ODDSEM", registrationdesc: "2026ODDSEM" }];
+  }
+
+  async get_add_drop_status() {
+    return {
+      lockFlag: false,
+      totalsubjectDetailList: [{
+        subjectid: "ADD-DROP-001",
+        subjectcode: "26B14CS354",
+        subjectdesc: "SCALABLE DATA SCIENCE",
+        choicetype: "Add request against an elective allocation",
+        totalStages: ["Submitted on 25-Jul-2026 03:42 PM@D", "1. Review Date:- 03-Aug-2026 01:05 PM by TIMETABLE COMMITTEE@D", "2. Approved Date:- 05-Aug-2026 10:25 AM by HOD@D"],
+      }],
+      subjectListrejected: [],
+    };
+  }
+
 }

--- a/jportal/src/components/MockWebPortal.js
+++ b/jportal/src/components/MockWebPortal.js
@@ -133,4 +133,35 @@ export default class MockWebPortal {
   async get_registered_semesters() {
     return fakeData.subjects.semestersData.semesters;
   }
+
+  async get_mooc_subject_status_semesters() {
+    return [
+      {
+        registrationid: "JIRUM26040000001",
+        registrationcode: "2026ODDSEM",
+        registrationdesc: "2026ODDSEM",
+      },
+    ];
+  }
+
+  async get_mooc_subject_status() {
+    return {
+      lockFlag: false,
+      duesAmount: 0,
+      onlyapprovedbyvc: "N",
+      totalsubjectDetailList: [
+        {
+          subjectid: "MOOC-001",
+          subjectcode: "26B14CS354",
+          subjectdesc: "SCALABLE DATA SCIENCE",
+          choicetype: "CURRENT Against (26B12CS319-FUNDAMENTALS OF SENSOR TECHNOLOGY AND ANDROID PROGRAMMING)",
+          totalStages: [
+            "Submitted on 25-Jul-2026 03:42 PM@D",
+            "1. Review Date:- 03-Aug-2026 01:05 PM by PRATIK SHRIVASTAVA (REVIEW BY MOOCD)@D",
+          ],
+        },
+      ],
+    };
+  }
+
 }

--- a/jportal/src/components/MoocStatus.jsx
+++ b/jportal/src/components/MoocStatus.jsx
@@ -2,6 +2,12 @@ import { CalendarDays, UserRound } from "lucide-react";
 import { Card } from "@/components/ui/card";
 
 const datePattern = /\d{1,2}-[A-Za-z]{3}-\d{4}\s+\d{1,2}:\d{2}\s+[AP]M/;
+const standardStages = [
+  "Choice Submitted",
+  "Review by Dept. MOOC Coordinator",
+  "Finalized by MOOC Coordinator",
+  "Final Allocation",
+];
 
 function parseStage(raw, index) {
   const [text, status = ""] = raw.split("@");
@@ -51,9 +57,19 @@ export default function MoocStatus({ moocStatus }) {
       </div>
 
       {subjects.map((subject) => {
-        const stages = subject.totalStages
-          .filter(Boolean)
-          .map((stage, index) => parseStage(stage, index));
+        const stageNames = moocStatus.onlyapprovedbyvc === "Y"
+          ? [standardStages[0], standardStages[3]]
+          : standardStages;
+        const stages = stageNames.map((title, index) => {
+          const raw = subject.totalStages?.[index];
+          return raw ? { ...parseStage(raw, index), title } : {
+            index,
+            status: "",
+            date: null,
+            coordinator: null,
+            title,
+          };
+        });
 
         return (
           <Card key={subject.subjectid} className="overflow-hidden shadow-lg">
@@ -92,6 +108,7 @@ export default function MoocStatus({ moocStatus }) {
                   <div className="min-w-0 flex-1 pb-1">
                     <p className="text-sm font-medium text-card-foreground">{stage.title}</p>
                     <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1.5 text-xs text-muted-foreground">
+                      <span>{stage.status === "D" ? "Completed" : "Pending"}</span>
                       {stage.date && (
                         <span className="inline-flex items-center gap-1.5">
                           <CalendarDays className="h-3.5 w-3.5" />

--- a/jportal/src/components/MoocStatus.jsx
+++ b/jportal/src/components/MoocStatus.jsx
@@ -1,0 +1,117 @@
+import { CalendarDays, UserRound } from "lucide-react";
+import { Card } from "@/components/ui/card";
+
+const datePattern = /\d{1,2}-[A-Za-z]{3}-\d{4}\s+\d{1,2}:\d{2}\s+[AP]M/;
+
+function parseStage(raw, index) {
+  const [text, status = ""] = raw.split("@");
+  const date = text.match(datePattern)?.[0] || null;
+  const coordinator = text.match(/\bby\s+(.+?)(?:\s*\(|$)/i)?.[1]?.trim() || null;
+  const title = text
+    .replace(datePattern, "")
+    .replace(/\bby\s+.+?(?:\s*\([^)]*\))?$/i, "")
+    .replace(/(?:Date:-|Submitted on)\s*$/i, "")
+    .replace(/^\d+\.\s*/, "")
+    .trim();
+
+  return {
+    index,
+    text: text.trim(),
+    status,
+    date,
+    coordinator,
+    title: title || text.trim(),
+  };
+}
+
+export default function MoocStatus({ moocStatus }) {
+  const subjects = moocStatus?.totalsubjectDetailList || [];
+
+  if (subjects.length === 0) {
+    return (
+      <div className="flex items-center justify-center py-12 text-muted-foreground">
+        No MOOC status found for this semester
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-4 space-y-4 pb-4">
+      <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+        {moocStatus.duesAmount > 0 && (
+          <span className="rounded-full border border-destructive/30 bg-destructive/10 px-3 py-1 font-medium text-destructive">
+            Pending dues: {moocStatus.duesAmount}
+          </span>
+        )}
+        {moocStatus.onlyapprovedbyvc === "Y" && (
+          <span className="rounded-full border border-border bg-muted px-3 py-1 font-medium">
+            Final approval only
+          </span>
+        )}
+      </div>
+
+      {subjects.map((subject) => {
+        const stages = subject.totalStages
+          .filter(Boolean)
+          .map((stage, index) => parseStage(stage, index));
+
+        return (
+          <Card key={subject.subjectid} className="overflow-hidden shadow-lg">
+            <div className="border-b border-border bg-muted/40 px-4 py-3">
+              <div className="flex items-start justify-between gap-4">
+                <div className="min-w-0">
+                  <h3 className="text-sm font-semibold leading-tight text-card-foreground">
+                    {subject.subjectdesc}
+                  </h3>
+                  <p className="mt-1 font-mono text-xs text-muted-foreground">{subject.subjectcode}</p>
+                </div>
+                <span className="shrink-0 rounded-full bg-primary px-2.5 py-1 text-xs font-semibold text-primary-foreground">
+                  {stages.length} stage{stages.length === 1 ? "" : "s"}
+                </span>
+              </div>
+              {subject.choicetype && (
+                <p className="mt-3 text-xs leading-relaxed text-muted-foreground">{subject.choicetype}</p>
+              )}
+            </div>
+
+            <div className="space-y-4 p-4">
+              {stages.map((stage, index) => (
+                <div key={`${subject.subjectid}-${stage.index}`} className="relative flex gap-3">
+                  {index < stages.length - 1 && (
+                    <div className="absolute left-3 top-7 h-[calc(100%-0.25rem)] w-px bg-border" />
+                  )}
+                  <div
+                    className={`relative z-10 flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-bold ${
+                      stage.status === "D"
+                        ? "bg-primary text-primary-foreground"
+                        : "bg-muted text-muted-foreground"
+                    }`}
+                  >
+                    {index + 1}
+                  </div>
+                  <div className="min-w-0 flex-1 pb-1">
+                    <p className="text-sm font-medium text-card-foreground">{stage.title}</p>
+                    <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1.5 text-xs text-muted-foreground">
+                      {stage.date && (
+                        <span className="inline-flex items-center gap-1.5">
+                          <CalendarDays className="h-3.5 w-3.5" />
+                          {stage.date}
+                        </span>
+                      )}
+                      {stage.coordinator && (
+                        <span className="inline-flex items-center gap-1.5">
+                          <UserRound className="h-3.5 w-3.5" />
+                          {stage.coordinator}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/jportal/src/components/Subjects.jsx
+++ b/jportal/src/components/Subjects.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import SubjectInfoCard from "./SubjectInfoCard";
+import MoocStatus from "./MoocStatus";
 import {
   Select,
   SelectContent,
@@ -26,39 +27,61 @@ export default function Subjects({
   subjectsLoading,
   setSubjectsLoading,
   choicesLoading,
-  setChoicesLoading
+  setChoicesLoading,
+  moocStatusData,
+  setMoocStatusData,
+  moocStatusLoading,
+  setMoocStatusLoading
 }) {
-  const displayedSemesters = activeTab === "choices"
-    ? semestersData?.choice_semesters
-    : semestersData?.registered_semesters || semestersData?.semesters;
+  const isChoicesTab = activeTab === "choices";
+  const isMoocTab = activeTab === "mooc";
+  const displayedSemesters = isMoocTab
+    ? semestersData?.mooc_semesters
+    : isChoicesTab
+      ? semestersData?.choice_semesters
+      : semestersData?.registered_semesters || semestersData?.semesters;
 
   useEffect(() => {
     let cancelled = false;
 
     const fetchSubjectsForTab = async () => {
       const isChoicesTab = activeTab === "choices";
+      const isMoocTab = activeTab === "mooc";
 
       try {
-        let semesterList = isChoicesTab
-          ? semestersData?.choice_semesters
-          : semestersData?.registered_semesters || semestersData?.semesters;
+        let semesterList = isMoocTab
+          ? semestersData?.mooc_semesters
+          : isChoicesTab
+            ? semestersData?.choice_semesters
+            : semestersData?.registered_semesters || semestersData?.semesters;
 
         if (!semesterList) {
           setLoading(true);
-          semesterList = isChoicesTab && w.get_semesters_for_grade_card
-            ? await w.get_semesters_for_grade_card()
-            : await w.get_registered_semesters();
+          if (isMoocTab) {
+            const moocSemesters = await w.get_mooc_subject_status_semesters();
+            semesterList = moocSemesters.map((semester) => ({
+              registration_id: semester.registrationid,
+              registration_code: semester.registrationcode,
+              registration_desc: semester.registrationdesc,
+            }));
+          } else {
+            semesterList = isChoicesTab && w.get_semesters_for_grade_card
+              ? await w.get_semesters_for_grade_card()
+              : await w.get_registered_semesters();
+          }
 
           if (cancelled) return;
 
           setSemestersData(prev => ({
             ...prev,
-            semesters: prev?.semesters || (!isChoicesTab ? semesterList : undefined),
-            latest_semester: prev?.latest_semester || (!isChoicesTab ? semesterList[0] : undefined),
-            registered_semesters: !isChoicesTab ? semesterList : prev?.registered_semesters,
-            latest_registered_semester: !isChoicesTab ? semesterList[0] : prev?.latest_registered_semester,
+            semesters: prev?.semesters || (!isChoicesTab && !isMoocTab ? semesterList : undefined),
+            latest_semester: prev?.latest_semester || (!isChoicesTab && !isMoocTab ? semesterList[0] : undefined),
+            registered_semesters: !isChoicesTab && !isMoocTab ? semesterList : prev?.registered_semesters,
+            latest_registered_semester: !isChoicesTab && !isMoocTab ? semesterList[0] : prev?.latest_registered_semester,
             choice_semesters: isChoicesTab ? semesterList : prev?.choice_semesters,
             latest_choice_semester: isChoicesTab ? semesterList[0] : prev?.latest_choice_semester,
+            mooc_semesters: isMoocTab ? semesterList : prev?.mooc_semesters,
+            latest_mooc_semester: isMoocTab ? semesterList[0] : prev?.latest_mooc_semester,
           }));
         }
 
@@ -71,7 +94,17 @@ export default function Subjects({
           setSelectedSem(semester);
         }
 
-        if (isChoicesTab) {
+        if (isMoocTab) {
+          if (!moocStatusData?.[semester.registration_id]) {
+            setMoocStatusLoading(true);
+            const data = await w.get_mooc_subject_status(semester);
+            if (cancelled) return;
+            setMoocStatusData(prev => ({
+              ...prev,
+              [semester.registration_id]: data
+            }));
+          }
+        } else if (isChoicesTab) {
           if (!subjectChoices?.[semester.registration_id]) {
             setChoicesLoading(true);
             const choicesData = await w.get_subject_choices(semester);
@@ -97,6 +130,7 @@ export default function Subjects({
           setLoading(false);
           setSubjectsLoading(false);
           setChoicesLoading(false);
+          setMoocStatusLoading(false);
         }
       }
     };
@@ -113,6 +147,7 @@ export default function Subjects({
     selectedSem,
     subjectData,
     subjectChoices,
+    moocStatusData,
     setLoading,
     setSubjectsLoading,
     setChoicesLoading,
@@ -120,12 +155,17 @@ export default function Subjects({
     setSemestersData,
     setSubjectData,
     setSubjectChoices,
+    setMoocStatusData,
+    setMoocStatusLoading,
   ]);
 
   const handleSemesterChange = async (value) => {
     const isChoicesTab = activeTab === "choices";
+    const isMoocTab = activeTab === "mooc";
 
-    if (isChoicesTab) {
+    if (isMoocTab) {
+      setMoocStatusLoading(true);
+    } else if (isChoicesTab) {
       setChoicesLoading(true);
     } else {
       setSubjectsLoading(true);
@@ -137,6 +177,17 @@ export default function Subjects({
       if (!semester) return;
 
       setSelectedSem(semester);
+
+      if (isMoocTab) {
+        if (!moocStatusData?.[semester.registration_id]) {
+          const data = await w.get_mooc_subject_status(semester);
+          setMoocStatusData(prev => ({
+            ...prev,
+            [semester.registration_id]: data
+          }));
+        }
+        return;
+      }
 
       if (isChoicesTab) {
         if (!subjectChoices?.[semester.registration_id]) {
@@ -165,11 +216,13 @@ export default function Subjects({
     } finally {
       setSubjectsLoading(false);
       setChoicesLoading(false);
+      setMoocStatusLoading(false);
     }
   };
 
   const currentSubjects = selectedSem && subjectData?.[selectedSem.registration_id];
   const currentChoices = selectedSem && subjectChoices?.[selectedSem.registration_id];
+  const currentMoocStatus = selectedSem && moocStatusData?.[selectedSem.registration_id];
   const groupedSubjects = currentSubjects?.subjects?.reduce((acc, subject) => {
     const baseCode = subject.subject_code;
     if (!acc[baseCode]) {
@@ -210,7 +263,7 @@ export default function Subjects({
       </div>
 
       <Tabs value={activeTab} onValueChange={setActiveTab} className="px-3 pb-4">
-        <TabsList className="grid grid-cols-2 bg-background gap-3">
+        <TabsList className="grid h-auto w-full grid-cols-2 gap-2 bg-background sm:grid-cols-3">
           <TabsTrigger
             value="registered"
             className="cursor-pointer text-muted-foreground bg-background data-[state=active]:bg-muted data-[state=active]:text-foreground"
@@ -222,6 +275,12 @@ export default function Subjects({
             className="cursor-pointer text-muted-foreground bg-background data-[state=active]:bg-muted data-[state=active]:text-foreground"
           >
             Choices
+          </TabsTrigger>
+          <TabsTrigger
+            value="mooc"
+            className="cursor-pointer text-muted-foreground bg-background data-[state=active]:bg-muted data-[state=active]:text-foreground"
+          >
+            MOOC Status
           </TabsTrigger>
         </TabsList>
 
@@ -338,6 +397,17 @@ export default function Subjects({
               </div>
             )}
         </TabsContent>
+
+        <TabsContent value="mooc">
+          {moocStatusLoading ? (
+            <div className="flex items-center justify-center py-12 text-muted-foreground">
+              Loading MOOC status...
+            </div>
+          ) : (
+            <MoocStatus moocStatus={currentMoocStatus} />
+          )}
+        </TabsContent>
+
       </Tabs>
     </div>
   );

--- a/jportal/src/components/Subjects.jsx
+++ b/jportal/src/components/Subjects.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 import SubjectInfoCard from "./SubjectInfoCard";
 import MoocStatus from "./MoocStatus";
+import AddDropStatus from "./AddDropStatus";
 import {
   Select,
   SelectContent,
@@ -31,11 +32,20 @@ export default function Subjects({
   moocStatusData,
   setMoocStatusData,
   moocStatusLoading,
-  setMoocStatusLoading
+  setMoocStatusLoading,
+  addDropStatusData,
+  setAddDropStatusData,
+  addDropStatusLoading,
+  setAddDropStatusLoading,
+  addDropStatusError,
+  setAddDropStatusError
 }) {
   const isChoicesTab = activeTab === "choices";
   const isMoocTab = activeTab === "mooc";
-  const displayedSemesters = isMoocTab
+  const isAddDropTab = activeTab === "add-drop";
+  const displayedSemesters = isAddDropTab
+    ? semestersData?.add_drop_semesters
+    : isMoocTab
     ? semestersData?.mooc_semesters
     : isChoicesTab
       ? semestersData?.choice_semesters
@@ -47,9 +57,12 @@ export default function Subjects({
     const fetchSubjectsForTab = async () => {
       const isChoicesTab = activeTab === "choices";
       const isMoocTab = activeTab === "mooc";
+      const isAddDropTab = activeTab === "add-drop";
 
       try {
-        let semesterList = isMoocTab
+        let semesterList = isAddDropTab
+          ? semestersData?.add_drop_semesters
+          : isMoocTab
           ? semestersData?.mooc_semesters
           : isChoicesTab
             ? semestersData?.choice_semesters
@@ -57,7 +70,15 @@ export default function Subjects({
 
         if (!semesterList) {
           setLoading(true);
-          if (isMoocTab) {
+          if (isAddDropTab) {
+            setAddDropStatusError(null);
+            const addDropSemesters = await w.get_add_drop_status_semesters();
+            semesterList = addDropSemesters.map((semester) => ({
+              registration_id: semester.registrationid,
+              registration_code: semester.registrationcode,
+              registration_desc: semester.registrationdesc,
+            }));
+          } else if (isMoocTab) {
             const moocSemesters = await w.get_mooc_subject_status_semesters();
             semesterList = moocSemesters.map((semester) => ({
               registration_id: semester.registrationid,
@@ -74,14 +95,16 @@ export default function Subjects({
 
           setSemestersData(prev => ({
             ...prev,
-            semesters: prev?.semesters || (!isChoicesTab && !isMoocTab ? semesterList : undefined),
-            latest_semester: prev?.latest_semester || (!isChoicesTab && !isMoocTab ? semesterList[0] : undefined),
-            registered_semesters: !isChoicesTab && !isMoocTab ? semesterList : prev?.registered_semesters,
-            latest_registered_semester: !isChoicesTab && !isMoocTab ? semesterList[0] : prev?.latest_registered_semester,
+            semesters: prev?.semesters || (!isChoicesTab && !isMoocTab && !isAddDropTab ? semesterList : undefined),
+            latest_semester: prev?.latest_semester || (!isChoicesTab && !isMoocTab && !isAddDropTab ? semesterList[0] : undefined),
+            registered_semesters: !isChoicesTab && !isMoocTab && !isAddDropTab ? semesterList : prev?.registered_semesters,
+            latest_registered_semester: !isChoicesTab && !isMoocTab && !isAddDropTab ? semesterList[0] : prev?.latest_registered_semester,
             choice_semesters: isChoicesTab ? semesterList : prev?.choice_semesters,
             latest_choice_semester: isChoicesTab ? semesterList[0] : prev?.latest_choice_semester,
             mooc_semesters: isMoocTab ? semesterList : prev?.mooc_semesters,
             latest_mooc_semester: isMoocTab ? semesterList[0] : prev?.latest_mooc_semester,
+            add_drop_semesters: isAddDropTab ? semesterList : prev?.add_drop_semesters,
+            latest_add_drop_semester: isAddDropTab ? semesterList[0] : prev?.latest_add_drop_semester,
           }));
         }
 
@@ -94,7 +117,17 @@ export default function Subjects({
           setSelectedSem(semester);
         }
 
-        if (isMoocTab) {
+        if (isAddDropTab) {
+          if (!addDropStatusData?.[semester.registration_id]) {
+            setAddDropStatusLoading(true);
+            const data = await w.get_add_drop_status(semester);
+            if (cancelled) return;
+            setAddDropStatusData(prev => ({
+              ...prev,
+              [semester.registration_id]: data
+            }));
+          }
+        } else if (isMoocTab) {
           if (!moocStatusData?.[semester.registration_id]) {
             setMoocStatusLoading(true);
             const data = await w.get_mooc_subject_status(semester);
@@ -125,12 +158,20 @@ export default function Subjects({
         }
       } catch (err) {
         console.error(err);
+        if (isAddDropTab) {
+          setAddDropStatusError(
+            err.message.includes("No Regeistration Event found!")
+              ? "No add/drop registration event is currently available."
+              : "Unable to load add/drop status right now."
+          );
+        }
       } finally {
         if (!cancelled) {
           setLoading(false);
           setSubjectsLoading(false);
           setChoicesLoading(false);
           setMoocStatusLoading(false);
+          setAddDropStatusLoading(false);
         }
       }
     };
@@ -148,6 +189,7 @@ export default function Subjects({
     subjectData,
     subjectChoices,
     moocStatusData,
+    addDropStatusData,
     setLoading,
     setSubjectsLoading,
     setChoicesLoading,
@@ -157,13 +199,19 @@ export default function Subjects({
     setSubjectChoices,
     setMoocStatusData,
     setMoocStatusLoading,
+    setAddDropStatusData,
+    setAddDropStatusLoading,
+    setAddDropStatusError,
   ]);
 
   const handleSemesterChange = async (value) => {
     const isChoicesTab = activeTab === "choices";
     const isMoocTab = activeTab === "mooc";
+    const isAddDropTab = activeTab === "add-drop";
 
-    if (isMoocTab) {
+    if (isAddDropTab) {
+      setAddDropStatusLoading(true);
+    } else if (isMoocTab) {
       setMoocStatusLoading(true);
     } else if (isChoicesTab) {
       setChoicesLoading(true);
@@ -177,6 +225,18 @@ export default function Subjects({
       if (!semester) return;
 
       setSelectedSem(semester);
+
+      if (isAddDropTab) {
+        setAddDropStatusError(null);
+        if (!addDropStatusData?.[semester.registration_id]) {
+          const data = await w.get_add_drop_status(semester);
+          setAddDropStatusData(prev => ({
+            ...prev,
+            [semester.registration_id]: data
+          }));
+        }
+        return;
+      }
 
       if (isMoocTab) {
         if (!moocStatusData?.[semester.registration_id]) {
@@ -213,16 +273,21 @@ export default function Subjects({
       }
     } catch (err) {
       console.error(err);
+      if (isAddDropTab) {
+        setAddDropStatusError("Unable to load add/drop status right now.");
+      }
     } finally {
       setSubjectsLoading(false);
       setChoicesLoading(false);
       setMoocStatusLoading(false);
+      setAddDropStatusLoading(false);
     }
   };
 
   const currentSubjects = selectedSem && subjectData?.[selectedSem.registration_id];
   const currentChoices = selectedSem && subjectChoices?.[selectedSem.registration_id];
   const currentMoocStatus = selectedSem && moocStatusData?.[selectedSem.registration_id];
+  const currentAddDropStatus = selectedSem && addDropStatusData?.[selectedSem.registration_id];
   const groupedSubjects = currentSubjects?.subjects?.reduce((acc, subject) => {
     const baseCode = subject.subject_code;
     if (!acc[baseCode]) {
@@ -263,7 +328,7 @@ export default function Subjects({
       </div>
 
       <Tabs value={activeTab} onValueChange={setActiveTab} className="px-3 pb-4">
-        <TabsList className="grid h-auto w-full grid-cols-2 gap-2 bg-background sm:grid-cols-3">
+        <TabsList className="grid h-auto w-full grid-cols-2 gap-2 bg-background sm:grid-cols-4">
           <TabsTrigger
             value="registered"
             className="cursor-pointer text-muted-foreground bg-background data-[state=active]:bg-muted data-[state=active]:text-foreground"
@@ -281,6 +346,12 @@ export default function Subjects({
             className="cursor-pointer text-muted-foreground bg-background data-[state=active]:bg-muted data-[state=active]:text-foreground"
           >
             MOOC Status
+          </TabsTrigger>
+          <TabsTrigger
+            value="add-drop"
+            className="cursor-pointer text-muted-foreground bg-background data-[state=active]:bg-muted data-[state=active]:text-foreground"
+          >
+            Add/Drop Status
           </TabsTrigger>
         </TabsList>
 
@@ -405,6 +476,20 @@ export default function Subjects({
             </div>
           ) : (
             <MoocStatus moocStatus={currentMoocStatus} />
+          )}
+        </TabsContent>
+
+        <TabsContent value="add-drop">
+          {addDropStatusError ? (
+            <div className="flex items-center justify-center py-12 text-center text-muted-foreground">
+              {addDropStatusError}
+            </div>
+          ) : addDropStatusLoading ? (
+            <div className="flex items-center justify-center py-12 text-muted-foreground">
+              Loading add/drop status...
+            </div>
+          ) : (
+            <AddDropStatus addDropStatus={currentAddDropStatus} />
           )}
         </TabsContent>
 

--- a/jportal/vite.config.ts
+++ b/jportal/vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig(({ mode }) => {
           enabled: true,
         },
         workbox: {
+          cacheId: "jportal-v2",
           maximumFileSizeToCacheInBytes: 30 * 1024 ** 2, // 30MB
           globPatterns: ["**/*.{js,css,html,ico,png,svg,whl}"],
           runtimeCaching: [
@@ -94,6 +95,7 @@ export default defineConfig(({ mode }) => {
       },
     },
     server: {
+      allowedHosts: [".ngrok-free.app"],
       proxy: {
         "/api/cloudflare": {
           target: "https://api.cloudflare.com",

--- a/jportal/vite.config.ts
+++ b/jportal/vite.config.ts
@@ -24,7 +24,6 @@ export default defineConfig(({ mode }) => {
           enabled: true,
         },
         workbox: {
-          cacheId: "jportal-v2",
           maximumFileSizeToCacheInBytes: 30 * 1024 ** 2, // 30MB
           globPatterns: ["**/*.{js,css,html,ico,png,svg,whl}"],
           runtimeCaching: [
@@ -93,9 +92,8 @@ export default defineConfig(({ mode }) => {
         // Vite 7 can miss the older package entry metadata here, so pin the ESM build explicitly.
         "lucide-react": path.resolve(__dirname, "./node_modules/lucide-react/dist/esm/lucide-react.js"),
       },
-    },
+    }
     server: {
-      allowedHosts: [".ngrok-free.app"],
       proxy: {
         "/api/cloudflare": {
           target: "https://api.cloudflare.com",

--- a/jportal/vite.config.ts
+++ b/jportal/vite.config.ts
@@ -92,7 +92,7 @@ export default defineConfig(({ mode }) => {
         // Vite 7 can miss the older package entry metadata here, so pin the ESM build explicitly.
         "lucide-react": path.resolve(__dirname, "./node_modules/lucide-react/dist/esm/lucide-react.js"),
       },
-    }
+    },
     server: {
       proxy: {
         "/api/cloudflare": {


### PR DESCRIPTION
## Summary

Adds MOOC Status and Add/Drop Status under Subjects.

- Adds MOOC status timelines with dates, coordinator names, and explicit completed/pending states
- Always displays the full MOOC workflow, including Final Allocation
- Adds Add/Drop Status beside MOOC Status
- Handles the no-active-add/drop-event state
- Supports rejected-subject data when provided by the portal
- Adds demo data for both status views
- Uses semantic theme tokens, supporting all existing themes
- Updates JSJIIT CDN import to `0.0.28`
- Bumps the Workbox cache namespace to `jportal-v2`

